### PR TITLE
Implement mul for uint128_t

### DIFF
--- a/include/boost/int128/detail/knuth_mul.hpp
+++ b/include/boost/int128/detail/knuth_mul.hpp
@@ -1,0 +1,58 @@
+// Copyright 2025 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_INT128_DETAIL_KNUTH_MUL_HPP
+#define BOOST_INT128_DETAIL_KNUTH_MUL_HPP
+
+// See: The Art of Computer Programming Volume 2 (Semi-numerical algorithms) section 4.3.1
+// Algorithm M: Multiplication of Non-negative integers
+
+#include <boost/int128/detail/config.hpp>
+#include <cstdint>
+
+namespace boost {
+namespace int128 {
+namespace detail {
+
+template <typename ReturnType, std::size_t u_size, std::size_t v_size>
+BOOST_INT128_FORCE_INLINE constexpr ReturnType knuth_multiply(const std::uint32_t (&u)[u_size],
+                                                              const std::uint32_t (&v)[v_size]) noexcept
+{
+    std::uint32_t w[4] {};
+
+    // M.1
+    for (std::size_t j {}; j < v_size; ++j)
+    {
+        // M.2
+        if (v[j] == 0)
+        {
+            v[j + u_size] = 0;
+            continue;
+        }
+
+        // M.3
+        std::uint64_t t {};
+        for (std::size_t i {}; i < u_size; ++i)
+        {
+            // M.4
+            t += static_cast<std::uint64_t>(u[i]) * v[j] + w[i + j];
+            w[i + j] = static_cast<std::uint32_t>(t);
+            t >>= 32u;
+        }
+
+        // M.5
+        w[j + u_size] = static_cast<std::uint32_t>(t);
+    }
+
+    const auto low {static_cast<std::uint64_t>(w[0]) | (static_cast<std::uint64_t>(w[1]) << 32)};
+    const auto high {static_cast<std::uint64_t>(w[2]) | (static_cast<std::uint64_t>(w[3]) << 32)};
+
+    return {high, low};
+}
+
+} // namespace detail
+} // namespace int128
+} // namespace boost
+
+#endif // BOOST_INT128_DETAIL_KNUTH_MUL_HPP

--- a/include/boost/int128/detail/knuth_mul.hpp
+++ b/include/boost/int128/detail/knuth_mul.hpp
@@ -53,6 +53,26 @@ BOOST_INT128_FORCE_INLINE constexpr ReturnType knuth_multiply(const std::uint32_
     return {static_cast<high_word_type>(high), low};
 }
 
+BOOST_INT128_FORCE_INLINE constexpr void to_words(const std::uint64_t x, std::uint32_t (&words)[2]) noexcept
+{
+    #ifndef BOOST_INT128_NO_CONSTEVAL_DETECTION
+
+    if (!BOOST_INT128_IS_CONSTANT_EVALUATED(x))
+    {
+        std::memcpy(&words, &x, sizeof(std::uint64_t));
+    }
+
+    #endif
+
+    words[0] = static_cast<std::uint32_t>(x & UINT32_MAX);
+    words[1] = static_cast<std::uint32_t>(x >> 32);
+}
+
+BOOST_INT128_FORCE_INLINE constexpr void to_words(const std::uint32_t x, std::uint32_t (&words)[1]) noexcept
+{
+    words[0] = x;
+}
+
 } // namespace detail
 } // namespace int128
 } // namespace boost

--- a/include/boost/int128/detail/knuth_mul.hpp
+++ b/include/boost/int128/detail/knuth_mul.hpp
@@ -19,6 +19,8 @@ template <typename ReturnType, std::size_t u_size, std::size_t v_size>
 BOOST_INT128_FORCE_INLINE constexpr ReturnType knuth_multiply(const std::uint32_t (&u)[u_size],
                                                               const std::uint32_t (&v)[v_size]) noexcept
 {
+    using high_word_type = decltype(ReturnType{}.high);
+
     std::uint32_t w[u_size + v_size] {};
 
     // M.1
@@ -48,7 +50,7 @@ BOOST_INT128_FORCE_INLINE constexpr ReturnType knuth_multiply(const std::uint32_
     const auto low {static_cast<std::uint64_t>(w[0]) | (static_cast<std::uint64_t>(w[1]) << 32)};
     const auto high {static_cast<std::uint64_t>(w[2]) | (static_cast<std::uint64_t>(w[3]) << 32)};
 
-    return {high, low};
+    return {static_cast<high_word_type>(high), low};
 }
 
 } // namespace detail

--- a/include/boost/int128/detail/knuth_mul.hpp
+++ b/include/boost/int128/detail/knuth_mul.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/int128/detail/config.hpp>
 #include <cstdint>
+#include <cstring>
 
 namespace boost {
 namespace int128 {

--- a/include/boost/int128/detail/knuth_mul.hpp
+++ b/include/boost/int128/detail/knuth_mul.hpp
@@ -19,7 +19,7 @@ template <typename ReturnType, std::size_t u_size, std::size_t v_size>
 BOOST_INT128_FORCE_INLINE constexpr ReturnType knuth_multiply(const std::uint32_t (&u)[u_size],
                                                               const std::uint32_t (&v)[v_size]) noexcept
 {
-    std::uint32_t w[4] {};
+    std::uint32_t w[u_size + v_size] {};
 
     // M.1
     for (std::size_t j {}; j < v_size; ++j)
@@ -27,7 +27,7 @@ BOOST_INT128_FORCE_INLINE constexpr ReturnType knuth_multiply(const std::uint32_
         // M.2
         if (v[j] == 0)
         {
-            v[j + u_size] = 0;
+            w[j + u_size] = 0;
             continue;
         }
 

--- a/include/boost/int128/detail/uint128_imp.hpp
+++ b/include/boost/int128/detail/uint128_imp.hpp
@@ -1628,26 +1628,6 @@ BOOST_INT128_FORCE_INLINE constexpr void to_words(const uint128_t& x, std::uint3
     words[3] = static_cast<std::uint32_t>(x.high >> 32);
 }
 
-BOOST_INT128_FORCE_INLINE constexpr void to_words(const std::uint64_t x, std::uint32_t (&words)[2]) noexcept
-{
-    #ifndef BOOST_INT128_NO_CONSTEVAL_DETECTION
-
-    if (!BOOST_INT128_IS_CONSTANT_EVALUATED(x))
-    {
-        std::memcpy(&words, &x, sizeof(std::uint64_t));
-    }
-
-    #endif
-
-    words[0] = static_cast<std::uint32_t>(x & UINT32_MAX);
-    words[1] = static_cast<std::uint32_t>(x >> 32);
-}
-
-BOOST_INT128_FORCE_INLINE constexpr void to_words(const std::uint32_t x, std::uint32_t (&words)[1]) noexcept
-{
-    words[0] = x;
-}
-
 template <typename UnsignedInteger>
 BOOST_INT128_FORCE_INLINE constexpr uint128_t default_mul(const uint128_t lhs, const UnsignedInteger rhs) noexcept
 {

--- a/include/boost/int128/detail/uint128_imp.hpp
+++ b/include/boost/int128/detail/uint128_imp.hpp
@@ -5,7 +5,6 @@
 #ifndef BOOST_INT128_DETAIL_UINT128_HPP
 #define BOOST_INT128_DETAIL_UINT128_HPP
 
-#include <boost/int128/detail/fwd.hpp>
 #include <boost/int128/detail/config.hpp>
 #include <boost/int128/detail/traits.hpp>
 #include <boost/int128/detail/constants.hpp>
@@ -171,6 +170,12 @@ uint128_t
     constexpr uint128_t& operator-=(Integer rhs) noexcept;
 
     constexpr uint128_t& operator-=(uint128_t rhs) noexcept;
+
+    // Compound Multiplication
+    template <BOOST_INT128_DEFAULTED_INTEGER_CONCEPT>
+    constexpr uint128_t& operator*=(Integer rhs) noexcept;
+
+    constexpr uint128_t& operator*=(uint128_t rhs) noexcept;
 };
 
 //=====================================
@@ -1591,6 +1596,23 @@ constexpr uint128_t& uint128_t::operator-=(const Integer rhs) noexcept
 constexpr uint128_t& uint128_t::operator-=(const uint128_t rhs) noexcept
 {
     *this = *this - rhs;
+    return *this;
+}
+
+//=====================================
+// Multiplication Operator
+//=====================================
+
+template <BOOST_INT128_INTEGER_CONCEPT>
+constexpr uint128_t& uint128_t::operator*=(const Integer rhs) noexcept
+{
+    *this = *this * rhs;
+    return *this;
+}
+
+constexpr uint128_t& uint128_t::operator*=(const uint128_t rhs) noexcept
+{
+    *this = *this * rhs;
     return *this;
 }
 

--- a/include/boost/int128/detail/uint128_imp.hpp
+++ b/include/boost/int128/detail/uint128_imp.hpp
@@ -1655,13 +1655,23 @@ BOOST_INT128_FORCE_INLINE constexpr uint128_t default_mul(const uint128_t lhs, c
 template <BOOST_INT128_DEFAULTED_SIGNED_INTEGER_CONCEPT>
 constexpr uint128_t operator*(const uint128_t lhs, const SignedInteger rhs) noexcept
 {
-    return detail::default_mul(lhs, static_cast<std::uint64_t>(rhs));
+    using eval_type = detail::evaluation_type_t<SignedInteger>;
+
+    const auto abs_rhs {rhs < 0 ? -static_cast<eval_type>(rhs) : static_cast<eval_type>(rhs)};
+    const auto res {detail::default_mul(lhs, abs_rhs)};
+
+    return rhs < 0 ? -res : res;
 }
 
 template <BOOST_INT128_DEFAULTED_SIGNED_INTEGER_CONCEPT>
 constexpr uint128_t operator*(const SignedInteger lhs, const uint128_t rhs) noexcept
 {
-    return detail::default_mul(rhs, static_cast<std::uint64_t>(lhs));
+    using eval_type = detail::evaluation_type_t<SignedInteger>;
+
+    const auto abs_lhs {lhs < 0 ? -static_cast<eval_type>(lhs) : static_cast<eval_type>(lhs)};
+    const auto res {detail::default_mul(rhs, abs_lhs)};
+
+    return lhs < 0 ? -res : res;
 }
 
 template <BOOST_INT128_DEFAULTED_UNSIGNED_INTEGER_CONCEPT>
@@ -1685,12 +1695,18 @@ constexpr uint128_t operator*(const uint128_t lhs, const uint128_t rhs) noexcept
 
 constexpr uint128_t operator*(const uint128_t lhs, const detail::builtin_i128 rhs) noexcept
 {
-    return lhs * static_cast<uint128_t>(rhs);
+    const auto abs_rhs {rhs < 0 ? -static_cast<uint128_t>(rhs) : static_cast<uint128_t>(rhs)};
+    const auto res {lhs * abs_rhs};
+
+    return rhs < 0 ? -res : res;
 }
 
 constexpr uint128_t operator*(const detail::builtin_i128 lhs, const uint128_t rhs) noexcept
 {
-    return static_cast<uint128_t>(lhs) * rhs;
+    const auto abs_lhs {lhs < 0 ? -static_cast<uint128_t>(lhs) : static_cast<uint128_t>(lhs)};
+    const auto res {abs_lhs * rhs};
+
+    return lhs < 0 ? -res : res;
 }
 
 constexpr uint128_t operator*(const uint128_t lhs, const detail::builtin_u128 rhs) noexcept

--- a/test/benchmark_i128.cpp
+++ b/test/benchmark_i128.cpp
@@ -2,7 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#if defined(NDEBUG) && !defined(UBSAN)
+#if defined(NDEBUG) && !defined(UBSAN) && !defined(ASAN)
 #define BOOST_INT128_BENCHMARK_I128
 #endif // NDEBUG
 

--- a/test/benchmark_u128.cpp
+++ b/test/benchmark_u128.cpp
@@ -2,7 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#if defined(NDEBUG) && !defined(UBSAN)
+#if defined(NDEBUG) && !defined(UBSAN) && !defined(ASAN)
 #define BOOST_INT128_BENCHMARK_U128
 #endif // NDEBUG
 

--- a/test/test_u128.cpp
+++ b/test/test_u128.cpp
@@ -823,6 +823,26 @@ void test_operator_sub()
     }
 }
 
+template <typename IntType>
+void test_operator_mul()
+{
+    boost::random::uniform_int_distribution<IntType> dist(get_root_min<IntType>(),
+                                                          get_root_max<IntType>());
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        IntType value {dist(rng)};
+        IntType value2 {dist(rng)};
+
+        auto builtin_value = static_cast<builtin_u128>(value);
+        boost::int128::uint128_t emulated_value {value};
+
+        auto check_1_value {emulated_value};
+        check_1_value *= value2;
+        BOOST_TEST(check_1_value == (builtin_value * value2));
+        BOOST_TEST((value2 * emulated_value) == (value2 * builtin_value));
+    }
+}
 
 struct test_caller
 {
@@ -858,6 +878,7 @@ struct test_caller
 
         test_operator_add<T>();
         test_operator_sub<T>();
+        test_operator_mul<T>();
     }
 };
 


### PR DESCRIPTION
Closes: #40 

Provides a portable knuth so that we can remove the one from int128_t in the future