### PR TITLE
Handle matters of trivial syntax

### DIFF
--- a/include/boost/int128/detail/common_div.hpp
+++ b/include/boost/int128/detail/common_div.hpp
@@ -2,8 +2,8 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#ifndef BOOST_INT128_DETAIL_KNUTH_DIV_HPP
-#define BOOST_INT128_DETAIL_KNUTH_DIV_HPP
+#ifndef BOOST_INT128_DETAIL_COMMON_DIV_HPP
+#define BOOST_INT128_DETAIL_COMMON_DIV_HPP
 
 #include <boost/int128/detail/config.hpp>
 #include <boost/int128/detail/clz.hpp>
@@ -554,4 +554,4 @@ BOOST_INT128_FORCE_INLINE constexpr T knuth_div(const T& dividend, const T& divi
 } // namespace int128
 } // namespace boost
 
-#endif // BOOST_INT128_DETAIL_KNUTH_DIV_HPP
+#endif // BOOST_INT128_DETAIL_COMMON_DIV_HPP

--- a/include/boost/int128/detail/common_mul.hpp
+++ b/include/boost/int128/detail/common_mul.hpp
@@ -2,8 +2,8 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#ifndef BOOST_INT128_DETAIL_KNUTH_MUL_HPP
-#define BOOST_INT128_DETAIL_KNUTH_MUL_HPP
+#ifndef BOOST_INT128_DETAIL_COMMON_MUL_HPP
+#define BOOST_INT128_DETAIL_COMMON_MUL_HPP
 
 #include <boost/int128/detail/config.hpp>
 #include <cstdint>
@@ -98,4 +98,4 @@ BOOST_INT128_FORCE_INLINE constexpr void to_words(const std::uint32_t x, std::ui
 } // namespace int128
 } // namespace boost
 
-#endif // BOOST_INT128_DETAIL_KNUTH_MUL_HPP
+#endif // BOOST_INT128_DETAIL_COMMON_MUL_HPP

--- a/include/boost/int128/detail/constants.hpp
+++ b/include/boost/int128/detail/constants.hpp
@@ -12,10 +12,10 @@ namespace boost {
 namespace int128 {
 namespace detail {
 
-static constexpr std::uint64_t low_word_mask {std::numeric_limits<std::uint64_t>::max()};
+static constexpr std::uint64_t low_word_mask {(std::numeric_limits<std::uint64_t>::max)()};
 
 template <typename T>
-static constexpr T offset_value_v = static_cast<T>(std::numeric_limits<std::uint64_t>::max());
+static constexpr T offset_value_v = static_cast<T>((std::numeric_limits<std::uint64_t>::max)());
 
 } // namespace detail
 } // namespace int128

--- a/include/boost/int128/detail/mini_to_chars.hpp
+++ b/include/boost/int128/detail/mini_to_chars.hpp
@@ -81,7 +81,7 @@ constexpr char* mini_to_chars(char (&buffer)[64], const int128_t v, const int ba
     if (v < 0)
     {
         // We cant negate the min value inside the signed type, but we know what the result will be
-        if (v == std::numeric_limits<int128_t>::min())
+        if (v == (std::numeric_limits<int128_t>::min)())
         {
             p = mini_to_chars(buffer, uint128_t{UINT64_C(0x8000000000000000), 0}, base, uppercase);
         }

--- a/include/boost/int128/detail/traits.hpp
+++ b/include/boost/int128/detail/traits.hpp
@@ -19,8 +19,9 @@ struct signed_integer
     static constexpr bool value = (std::is_signed<T>::value && std::is_integral<T>::value)
     #ifdef BOOST_INT128_HAS_INT128
     || std::is_same<T, builtin_i128>::value;
-    #endif
+    #else
     ;
+    #endif
 };
 
 template <typename T>
@@ -32,8 +33,9 @@ struct unsigned_integer
     static constexpr bool value = (std::is_unsigned<T>::value && std::is_integral<T>::value)
     #ifdef BOOST_INT128_HAS_INT128
     || std::is_same<T, builtin_u128>::value;
-    #endif
+    #else
     ;
+    #endif
 };
 
 template <typename T>

--- a/include/boost/int128/detail/uint128_imp.hpp
+++ b/include/boost/int128/detail/uint128_imp.hpp
@@ -2,8 +2,8 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#ifndef BOOST_INT128_DETAIL_UINT128_HPP
-#define BOOST_INT128_DETAIL_UINT128_HPP
+#ifndef BOOST_INT128_DETAIL_UINT128_IMP_HPP
+#define BOOST_INT128_DETAIL_UINT128_IMP_HPP
 
 #include <boost/int128/detail/fwd.hpp>
 #include <boost/int128/detail/config.hpp>
@@ -3058,4 +3058,4 @@ public:
 
 }// namespace std
 
-#endif //BOOST_INT128_DETAIL_UINT128_HPP
+#endif //BOOST_INT128_DETAIL_UINT128_IMP_HPP

--- a/include/boost/int128/numeric.hpp
+++ b/include/boost/int128/numeric.hpp
@@ -54,7 +54,7 @@ constexpr uint128_t add_sat(const uint128_t x, const uint128_t y) noexcept
 
     if (z < x)
     {
-        return std::numeric_limits<uint128_t>::max();
+        return (std::numeric_limits<uint128_t>::max)();
     }
 
     return z;
@@ -66,7 +66,7 @@ constexpr uint128_t sub_sat(const uint128_t x, const uint128_t y) noexcept
 
     if (z > x)
     {
-        return std::numeric_limits<uint128_t>::min();
+        return (std::numeric_limits<uint128_t>::min)();
     }
 
     return z;
@@ -85,12 +85,12 @@ constexpr int128_t add_sat(const int128_t x, const int128_t y) noexcept
 {
     if (x >= 0 && y >= 0)
     {
-        constexpr auto max_value {static_cast<uint128_t>(std::numeric_limits<int128_t>::max())};
+        constexpr auto max_value {static_cast<uint128_t>((std::numeric_limits<int128_t>::max)())};
         const auto big_x {static_cast<uint128_t>(x)};
         const auto big_y {static_cast<uint128_t>(y)};
         const auto big_res {big_x + big_y};
 
-        return big_res > max_value ? std::numeric_limits<int128_t>::max() : static_cast<int128_t>(big_res);
+        return big_res > max_value ? (std::numeric_limits<int128_t>::max)() : static_cast<int128_t>(big_res);
     }
     else if ((x < 0 && y > 0) || (x > 0 && y < 0))
     {
@@ -100,12 +100,12 @@ constexpr int128_t add_sat(const int128_t x, const int128_t y) noexcept
     {
         // x < 0 and y < 0
         // Nearly the same technique as the positive values case
-        constexpr auto max_value {-static_cast<uint128_t>(std::numeric_limits<int128_t>::min())};
+        constexpr auto max_value {-static_cast<uint128_t>((std::numeric_limits<int128_t>::min)())};
         const auto big_x {static_cast<uint128_t>(abs(x))};
         const auto big_y {static_cast<uint128_t>(abs(y))};
         const auto big_res {big_x + big_y};
 
-        return big_res > max_value ? std::numeric_limits<int128_t>::min() : -static_cast<int128_t>(big_res);
+        return big_res > max_value ? (std::numeric_limits<int128_t>::min)() : -static_cast<int128_t>(big_res);
     }
 }
 
@@ -115,17 +115,17 @@ constexpr int128_t sub_sat(const int128_t x, const int128_t y) noexcept
     {
         // Underflow case
         const auto res {x - y};
-        return res > x ? std::numeric_limits<int128_t>::min() : res;
+        return res > x ? (std::numeric_limits<int128_t>::min)() : res;
     }
     else if (x > 0 && y < 0)
     {
         // Overflow Case
-        constexpr auto max_val {static_cast<uint128_t>(std::numeric_limits<int128_t>::max())};
+        constexpr auto max_val {static_cast<uint128_t>((std::numeric_limits<int128_t>::max)())};
         const auto big_x {static_cast<uint128_t>(x)};
         const auto big_y {-static_cast<uint128_t>(y)};
         const auto res {big_x + big_y};
 
-        return (res > max_val || res < big_x) ? std::numeric_limits<int128_t>::max() : static_cast<int128_t>(res);
+        return (res > max_val || res < big_x) ? (std::numeric_limits<int128_t>::max)() : static_cast<int128_t>(res);
     }
     else
     {
@@ -144,7 +144,7 @@ constexpr uint128_t mul_sat(const uint128_t x, const uint128_t y) noexcept
 
     if ((x_bits + y_bits) > std::numeric_limits<uint128_t>::digits)
     {
-        return std::numeric_limits<uint128_t>::max();
+        return (std::numeric_limits<uint128_t>::max)();
     }
 
     return x * y;
@@ -159,11 +159,11 @@ constexpr int128_t mul_sat(const int128_t& x, const int128_t& y) noexcept
     {
         if ((x < 0) != (y < 0))
         {
-            return std::numeric_limits<int128_t>::min();
+            return (std::numeric_limits<int128_t>::min)();
         }
         else
         {
-            return std::numeric_limits<int128_t>::max();
+            return (std::numeric_limits<int128_t>::max)();
         }
     }
 
@@ -178,10 +178,10 @@ constexpr uint128_t div_sat(const uint128_t x, const uint128_t y) noexcept
 
 constexpr int128_t div_sat(const int128_t x, const int128_t y) noexcept
 {
-    if (BOOST_INT128_UNLIKELY(x == std::numeric_limits<int128_t>::min() && y == -1))
+    if (BOOST_INT128_UNLIKELY(x == (std::numeric_limits<int128_t>::min)() && y == -1))
     {
         // This is the only possible case of overflow
-        return std::numeric_limits<int128_t>::max();
+        return (std::numeric_limits<int128_t>::max)();
     }
 
     return x / y;
@@ -196,9 +196,9 @@ constexpr TargetType saturate_cast(const uint128_t value) noexcept
     }
     else
     {
-        if (value > static_cast<uint128_t>(std::numeric_limits<TargetType>::max()))
+        if (value > static_cast<uint128_t>((std::numeric_limits<TargetType>::max)()))
         {
-            return std::numeric_limits<TargetType>::max();
+            return (std::numeric_limits<TargetType>::max)();
         }
 
         return static_cast<TargetType>(value);
@@ -223,13 +223,13 @@ constexpr TargetType saturate_cast(const int128_t value) noexcept
     }
     else
     {
-        if (value > static_cast<int128_t>(std::numeric_limits<TargetType>::max()))
+        if (value > static_cast<int128_t>((std::numeric_limits<TargetType>::max)()))
         {
-            return std::numeric_limits<TargetType>::max();
+            return (std::numeric_limits<TargetType>::max)();
         }
-        else if (value < static_cast<int128_t>(std::numeric_limits<TargetType>::min()))
+        else if (value < static_cast<int128_t>((std::numeric_limits<TargetType>::min)()))
         {
-            return std::numeric_limits<TargetType>::min();
+            return (std::numeric_limits<TargetType>::min)();
         }
 
         return static_cast<TargetType>(value);


### PR DESCRIPTION
Hi Matt (@mborland)

I really appreciate your work on `cppallicnace/int128`. It is looking really good so far.

The purpose of this PR is to address matters of trivial syntax. It involves 3 main things.

- The changes in traits.hpp address an extra semicolon found with `-Wpedantic`. You don't have this warning in CI, probably on purpose. This was the only `-Wpedantic` warning that I found in my brief trials.
- Shield `(numeric_limits<T>::min)()` and `(numeric_limits<T>::max)()` from the MSVC `<windows.h>` header which actually `#define`s macros for `min()` and `max()`. This is a standard boost workaround and there is even a CI style checker that fails CI if the shielding parentheses are absent.
- Sync up some of the header guard definitions with the actual file names. I'm not sure if you'll want these changes, but they seemed to make sense to me.

There is a fourth item I observed. In Knuth long division [here](https://github.com/cppalliance/int128/blob/2d513a272297057b802773489b453b93f7ef0b32/include/boost/int128/detail/common_div.hpp#L151), there is a right-shift of signed `int64_t`. This requires an arithmetic right shift. In the old days, signed right shift was not guaranteed to properly handle the sign-bit (although I _never_ encountered a compiler that _did_ _not_ properly do arithmetic right shift). It is, however, I believe worth pointint out. I know that is a speed-critical routine, so it's maybe in the area of don't care?
  
