### PR TITLE
Fix `std::showbase` vs `std::noshowbase`

### DIFF
--- a/doc/modules/ROOT/pages/stream.adoc
+++ b/doc/modules/ROOT/pages/stream.adoc
@@ -44,7 +44,9 @@ The following flags from `<ios>` are supported for both streaming directions:
 - `std::oct` - Octal Numbers
 - `std::dec` - Decimal Numbers
 - `std::hex` - Hexadecimal Numbers
-- `std::uppercase` - Upper Case Formatting (e.g. 0XFFFF)
-- `std::nouppercase` - Lower Case Formatting (e.g. 0xffff)
+- `std::uppercase` - Upper Case Formatting (e.g. FFFF)
+- `std::nouppercase` - Lower Case Formatting (e.g. ffff)
+- `std::showbase` - Adds a leading base for hex or oct numbers (e.g. 0xffff)
+- `std::noshowbase` - Removes the leading base for hex or oct numbers (e.g. ffff)
 
 See the xref:examples.adoc#examples_io[IO streaming example] for usage demonstrations.

--- a/include/boost/int128/iostream.hpp
+++ b/include/boost/int128/iostream.hpp
@@ -124,14 +124,17 @@ auto operator<<(std::basic_ostream<charT, traits>& os, const LibIntegerType& v)
 
     auto first {detail::mini_to_chars(buffer, v, base, uppercase)};
 
-    if (base == 8)
+    if (flags & std::ios_base::showbase)
     {
-        *--first = '0';
-    }
-    else if (base == 16)
-    {
-        *--first = uppercase ? 'X' : 'x';
-        *--first = '0';
+        if (base == 8)
+        {
+            *--first = '0';
+        }
+        else if (base == 16)
+        {
+            *--first = uppercase ? 'X' : 'x';
+            *--first = '0';
+        }
     }
 
     BOOST_INT128_IF_CONSTEXPR (!std::is_same<charT, char>::value)

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -89,15 +89,25 @@ void test_ostream()
     std::stringstream hex_out;
     hex_out.flags(std::ios_base::hex);
     hex_out << hex_val;
-    BOOST_TEST_CSTR_EQ(hex_out.str().c_str(), "0xff");
+    BOOST_TEST_CSTR_EQ(hex_out.str().c_str(), "ff");
 
     // 32-bit windows does not set the flags correctly in CI
     #ifndef _M_IX86
 
+    std::stringstream hex_out_base;
+    hex_out_base.flags(std::ios_base::hex | std::ios_base::showbase);
+    hex_out_base << hex_val;
+    BOOST_TEST_CSTR_EQ(hex_out_base.str().c_str(), "0xff");
+
     std::stringstream hex_out_upper;
     hex_out_upper.flags(std::ios_base::hex | std::ios_base::uppercase);
     hex_out_upper << hex_val;
-    BOOST_TEST_CSTR_EQ(hex_out_upper.str().c_str(), "0XFF");
+    BOOST_TEST_CSTR_EQ(hex_out_upper.str().c_str(), "FF");
+
+    std::stringstream hex_out_upper_base;
+    hex_out_upper_base.flags(std::ios_base::hex | std::ios_base::uppercase | std::ios_base::showbase);
+    hex_out_upper_base << hex_val;
+    BOOST_TEST_CSTR_EQ(hex_out_upper_base.str().c_str(), "0XFF");
 
     #endif
 
@@ -105,7 +115,12 @@ void test_ostream()
     std::stringstream octal_out;
     octal_out.flags(std::ios_base::oct);
     octal_out << octal_val;
-    BOOST_TEST_CSTR_EQ(octal_out.str().c_str(), "04");
+    BOOST_TEST_CSTR_EQ(octal_out.str().c_str(), "4");
+
+    std::stringstream octal_out_upper;
+    octal_out_upper.flags(std::ios_base::hex | std::ios_base::showbase);
+    octal_out_upper << octal_val;
+    BOOST_TEST_CSTR_EQ(octal_out.str().c_str(), "4");
 
     BOOST_INT128_IF_CONSTEXPR (std::is_same<T, boost::int128::uint128_t>::value)
     {


### PR DESCRIPTION
Closes: #370 