### PR TITLE
Add support for C++26 `constexpr std::format`

### DIFF
--- a/doc/modules/ROOT/pages/format.adoc
+++ b/doc/modules/ROOT/pages/format.adoc
@@ -101,6 +101,7 @@ See the xref:examples.adoc#examples_fmt_format[formatting example] for a complet
 
 To use `std::format`, include `<boost/int128/format.hpp>` and `<format>`.
 The format specifiers described above work with `std::format`.
+If you are using `std::format` with pass:[C++26] or newer, `constexpr std::format` is supported.
 
 The xref:examples.adoc#examples_fmt_format[formatting example] can be trivially modified by including `<format>`,
 and replacing all instances of `fmt::` with `std::`

--- a/include/boost/int128/format.hpp
+++ b/include/boost/int128/format.hpp
@@ -20,6 +20,7 @@
 #define BOOST_INT128_HAS_FORMAT
 
 #if defined(__cpp_lib_constexpr_format) && __cpp_lib_constexpr_format >= 202511L
+#  define BOOST_INT128_HAS_CONSTEXPR_FORMAT
 #  define BOOST_INT128_CONSTEXPR_FORMAT constexpr
 #else
 #  define BOOST_INT128_CONSTEXPR_FORMAT

--- a/include/boost/int128/format.hpp
+++ b/include/boost/int128/format.hpp
@@ -19,6 +19,12 @@
 
 #define BOOST_INT128_HAS_FORMAT
 
+#if defined(__cpp_lib_constexpr_format) && __cpp_lib_constexpr_format >= 202511L
+#  define BOOST_INT128_CONSTEXPR_FORMAT constexpr
+#else
+#  define BOOST_INT128_CONSTEXPR_FORMAT
+#endif
+
 namespace boost::int128::detail {
 
 enum class sign_option
@@ -236,7 +242,7 @@ struct formatter<T>
     }
 
     template <typename FormatContext>
-    auto format(T v, FormatContext& ctx) const
+    BOOST_INT128_CONSTEXPR_FORMAT auto format(T v, FormatContext& ctx) const
     {
         char buffer[boost::int128::detail::mini_to_chars_buffer_size];
         bool isneg {false};

--- a/test/test_format.cpp
+++ b/test/test_format.cpp
@@ -4,6 +4,7 @@
 
 #include <boost/int128.hpp>
 #include <boost/int128/format.hpp>
+#include <boost/int128/literals.hpp>
 #include <boost/core/lightweight_test.hpp>
 
 #ifdef BOOST_INT128_HAS_FORMAT
@@ -182,6 +183,14 @@ void test_alignment_negative()
     BOOST_TEST_CSTR_EQ(std::format("{:*<6d}", T{-42}).c_str(), "-42***");
     BOOST_TEST_CSTR_EQ(std::format("{:*^7d}", T{-42}).c_str(), "**-42**");
 }
+
+#ifdef BOOST_INT128_HAS_CONSTEXPR_FORMAT
+
+using namespace boost::int128::literals;
+static_assert(std::format("num: {}", 1234_i128) == "num: 1234");
+static_assert(std::format("num: {}", 1234_u128) == "num: 1234");
+
+#endif
 
 int main()
 {


### PR DESCRIPTION
Closes: #428 